### PR TITLE
feat: Refactor proxy URL selection logic to prioritize HTTP over HTTPS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export async function getWindowsSystemProxy(): Promise<WindowsProxySettings | un
             : proxies['socks']
                 ? `socks://${proxies['socks']}`
             : proxies['https']
-                ? `https://${proxies['https']}`
+                ? `http://${proxies['https']}`
             : undefined;
 
         if (!proxyUrl) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,12 +51,12 @@ export async function getWindowsSystemProxy(): Promise<WindowsProxySettings | un
                 .map((proxyPair) => proxyPair.split('=') as [string, string])
         );
 
-        const proxyUrl = proxies['https']
-                ? `https://${proxies['https']}`
-            : proxies['http']
+        const proxyUrl = proxies['http']
                 ? `http://${proxies['http']}`
             : proxies['socks']
                 ? `socks://${proxies['socks']}`
+            : proxies['https']
+                ? `https://${proxies['https']}`
             : undefined;
 
         if (!proxyUrl) {


### PR DESCRIPTION
On Windows, few people use HTTPS proxies, and many tend to put HTTP proxy settings into the HTTPS configuration, causing TLS handshake failures and preventing proxy usage.

The Windows system does not support HTTPS proxies; it only supports HTTP and SOCKS proxies. Therefore, both HTTP and HTTPS proxy settings should return the HTTP proxy.


